### PR TITLE
Add Patch to explictly use OpenCV3 during build

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -13,7 +13,9 @@ pkgbase = ros-melodic-image-geometry
 	depends = ros-melodic-sensor-msgs
 	depends = opencv3-opt
 	source = ros-melodic-image-geometry-1.13.0.tar.gz::https://github.com/ros-perception/vision_opencv/archive/1.13.0.tar.gz
+	source = use-opencv3.patch
 	sha256sums = c8db35dbb6b470cdedb45195f725bc2cfda7f0dc3155e16a5a37e4b48e29fa59
+	sha256sums = 8937ccf72a7c463e2525cea0c5a3c1ac7f6ac7ea2b3dde79a929c99b57edb02e
 
 pkgname = ros-melodic-image-geometry
 

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-melodic-image-geometry
 	pkgdesc = ROS - image_geometry contains C++ and Python libraries for interpreting images geometrically.
 	pkgver = 1.13.0
-	pkgrel = 3
+	pkgrel = 4
 	url = https://wiki.ros.org/image_geometry
 	arch = any
 	license = BSD

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -29,8 +29,14 @@ depends=(
 )
 
 _dir="vision_opencv-${pkgver}/image_geometry"
-source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros-perception/vision_opencv/archive/${pkgver}.tar.gz")
-sha256sums=('c8db35dbb6b470cdedb45195f725bc2cfda7f0dc3155e16a5a37e4b48e29fa59')
+source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros-perception/vision_opencv/archive/${pkgver}.tar.gz" "use-opencv3.patch")
+sha256sums=('c8db35dbb6b470cdedb45195f725bc2cfda7f0dc3155e16a5a37e4b48e29fa59'
+            '8937ccf72a7c463e2525cea0c5a3c1ac7f6ac7ea2b3dde79a929c99b57edb02e')
+
+prepare() {
+    cd "${srcdir}"
+    patch --forward --strip=1  --input=${srcdir}/use-opencv3.patch || return 1
+}
 
 build() {
 	# Use ROS environment variables.

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@ url='https://wiki.ros.org/image_geometry'
 pkgname='ros-melodic-image-geometry'
 pkgver='1.13.0'
 arch=('any')
-pkgrel='3'
+pkgrel='4'
 license=('BSD')
 
 ros_makedepends=(

--- a/use-opencv3.patch
+++ b/use-opencv3.patch
@@ -1,0 +1,12 @@
+diff --unified --recursive --text package.orig/vision_opencv-1.13.0/image_geometry/CMakeLists.txt package.new/vision_opencv-1.13.0/image_geometry/CMakeLists.txt
+--- package.orig/vision_opencv-1.13.0/image_geometry/CMakeLists.txt	2020-05-21 15:32:19.474961287 +0200
++++ package.new/vision_opencv-1.13.0/image_geometry/CMakeLists.txt	2020-05-21 15:32:33.155009735 +0200
+@@ -2,7 +2,7 @@
+ project(image_geometry)
+ 
+ find_package(catkin REQUIRED sensor_msgs)
+-find_package(OpenCV REQUIRED)
++find_package(OpenCV 3 REQUIRED)
+ 
+ catkin_package(CATKIN_DEPENDS sensor_msgs
+                DEPENDS OpenCV


### PR DESCRIPTION
As discussed in https://github.com/ros-melodic-arch/ros-melodic-cv-bridge/issues/6, this pull request adds a patch to the CMakeLists to use OpenCV 3, which is already an explicit dependency in the PKGBUILD. Thus, the build is consistent with ros-melodic-cv-bridge. This should fix #1 .